### PR TITLE
Fix/pacifica ssc interface wrapper

### DIFF
--- a/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
@@ -27,11 +27,30 @@
   <include file="$(arg ssc_param_dir)/ne_dbw_connection.launch"/>
 
   <!-- SSC -->
+  <group>
+
+  <remap from="brake_cmd" to="$(arg vehicle_ns)/brake_cmd" />
+    <remap from="brake_info_report" to="$(arg vehicle_ns)/brake_info_report" />
+    <remap from="brake_report" to="$(arg vehicle_ns)/brake_report" />
+    <remap from="disable" to="$(arg vehicle_ns)/disable" />
+    <remap from="enable" to="$(arg vehicle_ns)/enable" />
+    <remap from="steering_cmd" to="$(arg vehicle_ns)/steering_cmd" />
+    <remap from="steering_report" to="$(arg vehicle_ns)/steering_report" />
+    <remap from="surround_report" to="$(arg vehicle_ns)/surround_report" />
+    <remap from="throttle_cmd" to="$(arg vehicle_ns)/throttle_cmd" />
+    <remap from="throttle_report" to="$(arg vehicle_ns)/throttle_report" />
+    <remap from="turn_signal_cmd" to="$(arg vehicle_ns)/turn_signal_cmd" />
+    <remap from="gear_cmd" to="$(arg vehicle_ns)/gear_cmd" />
+    <remap from="gear_report" to="$(arg vehicle_ns)/gear_report" />
+    <remap from="wheel_speed_report" to="$(arg vehicle_ns)/wheel_speed_report" />
+    <remap from="misc_1_report" to="$(arg vehicle_ns)/misc_1_report" />
+
+    
   <include file="$(find ssc_interface_wrapper)/launch/carma_speed_steering_control.launch">
     <arg name="param_dir" value="$(arg ssc_param_dir)"/>
     <arg name="ssc_package_name" value="ssc_ne_pacifica"/>
   </include>
-
+</group>
   <!-- SSC Interface -->
   <include file="$(find ssc_interface_wrapper)/launch/remapped_ssc_interface.launch"/>
 </launch>

--- a/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
@@ -29,23 +29,7 @@
   <!-- SSC -->
   <group>
 
-  <remap from="brake_cmd" to="$(arg vehicle_ns)/brake_cmd" />
-    <remap from="brake_info_report" to="$(arg vehicle_ns)/brake_info_report" />
-    <remap from="brake_report" to="$(arg vehicle_ns)/brake_report" />
-    <remap from="disable" to="$(arg vehicle_ns)/disable" />
-    <remap from="enable" to="$(arg vehicle_ns)/enable" />
-    <remap from="steering_cmd" to="$(arg vehicle_ns)/steering_cmd" />
-    <remap from="steering_report" to="$(arg vehicle_ns)/steering_report" />
-    <remap from="surround_report" to="$(arg vehicle_ns)/surround_report" />
-    <remap from="throttle_cmd" to="$(arg vehicle_ns)/throttle_cmd" />
-    <remap from="throttle_report" to="$(arg vehicle_ns)/throttle_report" />
-    <remap from="turn_signal_cmd" to="$(arg vehicle_ns)/turn_signal_cmd" />
-    <remap from="gear_cmd" to="$(arg vehicle_ns)/gear_cmd" />
-    <remap from="gear_report" to="$(arg vehicle_ns)/gear_report" />
-    <remap from="wheel_speed_report" to="$(arg vehicle_ns)/wheel_speed_report" />
-    <remap from="misc_1_report" to="$(arg vehicle_ns)/misc_1_report" />
-
-    
+  
   <include file="$(find ssc_interface_wrapper)/launch/carma_speed_steering_control.launch">
     <arg name="param_dir" value="$(arg ssc_param_dir)"/>
     <arg name="ssc_package_name" value="ssc_ne_pacifica"/>

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -15,15 +15,19 @@
  */
 
 #include "ssc_interface_wrapper_worker.h"
+#include <ros/ros.h>
 
 uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_time, double timeout)
 {
+	ROS_DEBUG_STREAM("TEST_NODE1");
+
     if(last_vehicle_status_time_.isZero() || latest_ssc_status_.compare("not_ready") == 0)
     {
         return cav_msgs::DriverStatus::OFF;
     }
     else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || latest_ssc_status_.compare("fatal") == 0 
 	|| latest_ssc_status_.compare("failure") == 0) {
+		ROS_DEBUG_STREAM("TEST_NODE2");
         return cav_msgs::DriverStatus::FAULT;
     }
     return cav_msgs::DriverStatus::OPERATIONAL;
@@ -64,5 +68,7 @@ int SSCInterfaceWrapperWorker::convert_shift_state_to_J2735(const pacmod_msgs::S
 
 bool SSCInterfaceWrapperWorker::is_engaged()
 {
+	ROS_DEBUG_STREAM("TEST_NODE_");
+
     return !latest_ssc_status_.compare("active");
 }

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -19,7 +19,6 @@
 
 uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_time, double timeout)
 {
-	ROS_DEBUG_STREAM("TEST_NODE1");
 
     if(last_vehicle_status_time_.isZero() || latest_ssc_status_.compare("not_ready") == 0)
     {
@@ -27,7 +26,6 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
     }
     else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || latest_ssc_status_.compare("fatal") == 0 
 	|| latest_ssc_status_.compare("failure") == 0) {
-		ROS_DEBUG_STREAM("TEST_NODE2");
         return cav_msgs::DriverStatus::FAULT;
     }
     return cav_msgs::DriverStatus::OPERATIONAL;
@@ -68,7 +66,6 @@ int SSCInterfaceWrapperWorker::convert_shift_state_to_J2735(const pacmod_msgs::S
 
 bool SSCInterfaceWrapperWorker::is_engaged()
 {
-	ROS_DEBUG_STREAM("TEST_NODE_");
 
     return !latest_ssc_status_.compare("active");
 }

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -22,7 +22,8 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
     {
         return cav_msgs::DriverStatus::OFF;
     }
-    else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || latest_ssc_status_.compare("fatal") == 0) {
+    else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || latest_ssc_status_.compare("fatal") == 0 
+	|| latest_ssc_status_.compare("failure") == 0) {
         return cav_msgs::DriverStatus::FAULT;
     }
     return cav_msgs::DriverStatus::OPERATIONAL;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Additional logic has been added to the SSC Interface Wrapper node in order to force system shutdown for the Pacifica. Since the only driver being monitored is the VEH Controller, the new code will send the SSC Failure alert when that device's status shifts from "active" to "failure".
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/1084#
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
During Vanden-Plas testing on the Black Pacifica, test case 5.4.3 Verify Control Handover ended as a failure. While Lidar + GPS Shutdown works as intended (UI prompts the driver to take manual control of the vehicle once the drivers have been disabled), the SSC Shutdown test failed: pressing the E-Stop button only stopped the vehicle and disengaged guidance. There were no alerts from the UI indicating SSC Failure and the /system_alert topic showed no messages indicating the driver was shut down.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in the Black Chrysler Pacifica using various docker images for both carma-ssc-interface-wrapper and carma-config.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.