### PR TITLE
fix manual override failing

### DIFF
--- a/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
+++ b/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
@@ -38,7 +38,7 @@ public:
     std::string get_current_ssc_state();
 
 private:
-    
+    std::string latest_ssc_status_info_;
     std::string latest_ssc_status_;
     ros::Time last_vehicle_status_time_;
 

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -25,7 +25,7 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
         return cav_msgs::DriverStatus::OFF;
     }
     else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || latest_ssc_status_.compare("fatal") == 0 
-	|| latest_ssc_status_.compare("failure") == 0) {
+	|| (latest_ssc_status_.compare("failure") == 0 && latest_ssc_status_info_.compare("Operator Override") != 0)) {
         return cav_msgs::DriverStatus::FAULT;
     }
     return cav_msgs::DriverStatus::OPERATIONAL;
@@ -39,6 +39,7 @@ void SSCInterfaceWrapperWorker::on_new_status_msg(const automotive_navigation_ms
 	{
             last_vehicle_status_time_ = current_time;
             latest_ssc_status_ = msg->state;
+			latest_ssc_status_info_ = msg->info;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR fixes the ssc error being triggered whe nthe driver manually takes control. 
When driver manually takes control, it gives same satus message as normal failing ,but it has extra info so we need to account for that.
<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
3.5.0 validation stesting
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.