### PR TITLE
Adjust pre_build hook for release builds

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -9,6 +9,6 @@ elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]]; then
     RELEASE_NAME=$(echo $SOURCE_BRANCH | cut -d "/" -f 2)
     sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:develop|:$RELEASE_NAME|g" \
         Dockerfile
-    sed -i "s|--branch .*|--branch $SOURCE_BRANCH|g" \
+    sed -i "s|--branch develop|--branch $SOURCE_BRANCH|g" \
         docker/checkout.bash
 fi


### PR DESCRIPTION
Fixes pre_build hook to convert `develop` into release named docker images. Specifically, this fix properly applies the regex to the carma respositories included in the checkout.bash script.