### PR TITLE
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1700

### DIFF
--- a/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
@@ -102,6 +102,10 @@ bool SSCInterfaceWrapper::enable_robotic_control_cb(cav_srvs::SetEnableRoboticRe
         engage_cmd.data = false;
         vehicle_engage_pub_.publish(engage_cmd);
         if(req.set == cav_srvs::SetEnableRoboticRequest::ENABLE) {
+            // This flag is required because the SSC needs to be sent a negative engagement after operator override 
+            // before it will accept a positive engagement.
+            // In the lines above we send the negative engagement, but we need to wait for the status to change again
+            // before we send the re-engagement. This flag tells us of the need to do that. 
             reengage_state_ = true;
         }
     }

--- a/ssc_interface_wrapper_ros2/include/ssc_interface_wrapper/ssc_interface_wrapper_node.hpp
+++ b/ssc_interface_wrapper_ros2/include/ssc_interface_wrapper/ssc_interface_wrapper_node.hpp
@@ -107,5 +107,6 @@ namespace ssc_interface_wrapper
             ////
             carma_ros2_utils::CallbackReturn handle_on_configure(const rclcpp_lifecycle::State &);
             carma_ros2_utils::CallbackReturn handle_on_activate(const rclcpp_lifecycle::State &);
+            carma_ros2_utils::CallbackReturn handle_on_deactivate(const rclcpp_lifecycle::State &);
     };
 } // ssc_interface_wrapper

--- a/ssc_interface_wrapper_ros2/src/ssc_interface_wrapper_node.cpp
+++ b/ssc_interface_wrapper_ros2/src/ssc_interface_wrapper_node.cpp
@@ -55,6 +55,8 @@ namespace ssc_interface_wrapper{
         //Load parameters
         get_parameter<double>("controller_timeout", config_.controller_timeout);
 
+        reengage_state_ = false;
+
         //setup subscribers
         ssc_state_sub_ = create_subscription<automotive_navigation_msgs::msg::ModuleState>("module_states", 5,
                                                                                         std::bind(&Node::ssc_state_cb, this, std::placeholders::_1));
@@ -75,8 +77,6 @@ namespace ssc_interface_wrapper{
         // initialize services
         enable_robotic_control_srv_ = create_service<carma_driver_msgs::srv::SetEnableRobotic>("controller/enable_robotic", 
                                                                                     std::bind(&Node::enable_robotic_control_cb, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));                                                                  
-
-        reengage_state_ = false;
         
         return CallbackReturn::SUCCESS;
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1700 by updating the ROS2 ssc interface wrapper
In order for the reengagement of the ssc to occur it must first be sent a disengagement signal. This is done in the guidance callback, but the follow up engagement signal requires waiting for the SSC to transition back to ready. In order for this to happen the corresponding flag needed to be checked. It was being checked in handle_on_activate instead of the state callback and so was never called when the state changed. This has been resolved.

Additionally, for increased safety the flag is now reset in on_configure and on_deactivate to ensure it cannot remain set if the user initiated a deactivation between signals which would cause auto reengagement on the subsequent lifecycle activation. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1700
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Functional reengage behavior
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Successfully tested in silver lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.