### PR TITLE
Fix/guard against timestamp comparison

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/autoware.ai:carma-system-4.0.0 AS base_image
+FROM usdotfhwastol/autoware.ai:carma-system-4.0.3 AS base_image
 
 FROM base_image as source-code
 

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -54,7 +54,7 @@ if [[ "$BRANCH" = "develop" ]]; then
       git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/CARMAMsgs --branch $BRANCH
       git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/CARMAUtils --branch $BRANCH
 else
-      git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/CARMAMsgs --branch carma-system-4.0.0
+      git clone https://github.com/usdot-fhwa-stol/carma-msgs.git ${dir}/src/CARMAMsgs --branch carma-system-4.0.3
       git clone https://github.com/usdot-fhwa-stol/carma-utils.git ${dir}/src/CARMAUtils --branch carma-system-4.0.0
 fi
 

--- a/ssc_interface_wrapper_ros2/include/ssc_interface_wrapper/converter_node.hpp
+++ b/ssc_interface_wrapper_ros2/include/ssc_interface_wrapper/converter_node.hpp
@@ -177,8 +177,8 @@ class Converter : public carma_ros2_utils::CarmaLifecycleNode
     
     ConverterConfig config_;
 
-    bool engage_;
-    bool command_initialized_; 
+    bool engage_ = false;
+    bool command_initialized_ = false; 
     double current_velocity_;
     double adaptive_gear_ratio_;
     rclcpp::Time command_time_;

--- a/ssc_interface_wrapper_ros2/include/ssc_interface_wrapper/ssc_interface_wrapper_node.hpp
+++ b/ssc_interface_wrapper_ros2/include/ssc_interface_wrapper/ssc_interface_wrapper_node.hpp
@@ -70,7 +70,7 @@ namespace ssc_interface_wrapper
             carma_driver_msgs::msg::RobotEnabled robotic_status_msg_;
 
             // bool flag indicates the wrapper is in the reengage mode
-            bool reengage_state_;
+            bool reengage_state_ = false;
 
             rclcpp::TimerBase::SharedPtr timer_;
 

--- a/ssc_interface_wrapper_ros2/package.xml
+++ b/ssc_interface_wrapper_ros2/package.xml
@@ -36,6 +36,7 @@
   <depend>cav_srvs</depend>
   <depend>carma_driver_msgs</depend>
   <depend>automotive_navigation_msgs</depend>
+  <depend>lifecycle_msgs</depend>
 
   <depend>automotive_platform_msgs</depend>
   <depend>autoware_msgs</depend>

--- a/ssc_interface_wrapper_ros2/src/converter_worker.cpp
+++ b/ssc_interface_wrapper_ros2/src/converter_worker.cpp
@@ -142,6 +142,11 @@ namespace ssc_interface_wrapper{
     }
 
     void Converter::callback_from_vehicle_cmd(const autoware_msgs::msg::VehicleCmd::UniquePtr msg){
+        // If the current state is not active we will return to avoid comparing timestamps from different time sources (ie. states)
+        if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+        {
+            return;
+        }
         command_time_ = this->now();
         vehicle_cmd_ = *msg;
         command_initialized_ = true;
@@ -431,6 +436,10 @@ namespace ssc_interface_wrapper{
         {
             // NOTE: HAZARD signal cannot be used in automotive_platform_msgs::msg::TurnSignalCommand
         }
+
+        std::cerr << "command initialized: " << command_initialized_ << std::endl;
+        std::cerr << "command_time_: " << command_time_.seconds() << std::endl;
+        std::cerr << "(this->now(): " << this->now().seconds() << std::endl;
 
          // Override desired speed to ZERO by emergency/timeout
         bool emergency = (vehicle_cmd_.emergency == 1);

--- a/ssc_interface_wrapper_ros2/src/converter_worker.cpp
+++ b/ssc_interface_wrapper_ros2/src/converter_worker.cpp
@@ -437,11 +437,7 @@ namespace ssc_interface_wrapper{
             // NOTE: HAZARD signal cannot be used in automotive_platform_msgs::msg::TurnSignalCommand
         }
 
-        std::cerr << "command initialized: " << command_initialized_ << std::endl;
-        std::cerr << "command_time_: " << command_time_.seconds() << std::endl;
-        std::cerr << "(this->now(): " << this->now().seconds() << std::endl;
-
-         // Override desired speed to ZERO by emergency/timeout
+        // Override desired speed to ZERO by emergency/timeout
         bool emergency = (vehicle_cmd_.emergency == 1);
         bool timeouted = command_initialized_ && (((this->now() - command_time_).seconds() * 1000) > config_.command_timeout_);
 

--- a/ssc_interface_wrapper_ros2/src/ssc_interface_wrapper_node.cpp
+++ b/ssc_interface_wrapper_ros2/src/ssc_interface_wrapper_node.cpp
@@ -14,6 +14,7 @@
  * the License.
  */
 #include "ssc_interface_wrapper/ssc_interface_wrapper_node.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 
 namespace ssc_interface_wrapper{
     
@@ -139,6 +140,12 @@ namespace ssc_interface_wrapper{
  
     void Node::ssc_state_cb(const automotive_navigation_msgs::msg::ModuleState::UniquePtr msg)
     {
+        // If the current state is not active we will return to avoid comparing timestamps from different time sources (ie. states)
+        if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+        {
+            return;
+        }
+
         // message needs to go to library. Unique ptr cant be sent
         automotive_navigation_msgs::msg::ModuleState module_state = *msg;
         worker_.on_new_status_msg(module_state, this->now());


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the ssc_wrapper_ros2 to properly initialize all its boolean variables. Previously it could incorrectly trip a timer exception caused by having a non-zero undefined value in the boolean flags. In addition, some state checks were added as an extra precaution though they might not be strictly needed. 
<!--- Describe your changes in detail -->

## Related Issue
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1729
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Stable SSC in ROS2
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in blue lexus for freight workzone use case
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.