### PR TITLE
Remove environment variable setting in launch file

### DIFF
--- a/ssc_interface_wrapper_ros2/launch/carma_speed_steering_control.launch.py
+++ b/ssc_interface_wrapper_ros2/launch/carma_speed_steering_control.launch.py
@@ -45,7 +45,8 @@ def generate_launch_description():
         declare_ssc_package_name,
         GroupAction(
             actions = [
-                SetEnvironmentVariable('RLM_LICENSE', value= PathJoinSubstitution([vehicle_calibration_dir,ssc_package_name, 'as_licenses'])),
+
+                # NOTE: In past versions of the system the RLM_LICENSE env variable was set here however it has been moved to the config due to this issue https://github.com/usdot-fhwa-stol/carma-platform/issues/2002
 
                 set_remap.SetRemap('/hardware_interface/as/speed_model/get_state', '/hardware_interface/as/speed_model/false_get_state'),
                 set_remap.SetRemap('/hardware_interface/as/speed_model/change_state', '/hardware_interface/as/speed_model/false_change_state'),


### PR DESCRIPTION
… the config

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR moves the RLM_LICENSE environment variable configuration from the SSC launch files to the config due to an apparent issue in the usage of the environment variable setting from within ROS2 launch. Setting the variable here globally for the whole docker image resolves this issue. Since this only occurs on the ROS2 SSC (lexus) only that config has been changed. 
## Related Issue
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/2002
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Functional DBW system
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified in Blue and Silver lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.