### PR TITLE
ROS1 Cleanup

### DIFF
--- a/ssc_interface_wrapper/CMakeLists.txt
+++ b/ssc_interface_wrapper/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(catkin REQUIRED COMPONENTS
   autoware_msgs
   can_msgs  
   pacmod_msgs
-  j2735_msgs
+  j2735_v2x_msgs
   roscpp
   automotive_navigation_msgs
 )
@@ -54,7 +54,7 @@ catkin_package(
         autoware_msgs
         can_msgs  
         pacmod_msgs
-        j2735_msgs
+        j2735_v2x_msgs
         roscpp
         automotive_navigation_msgs
 )

--- a/ssc_interface_wrapper/include/ssc_interface_wrapper.h
+++ b/ssc_interface_wrapper/include/ssc_interface_wrapper.h
@@ -20,7 +20,7 @@
 #include <cav_srvs/SetEnableRobotic.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float64.h>
-#include <j2735_msgs/TransmissionState.h>
+#include <j2735_v2x_msgs/TransmissionState.h>
 #include <pacmod_msgs/SystemRptFloat.h>
 #include <pacmod_msgs/SystemRptInt.h>
 #include <pacmod_msgs/SystemCmdBool.h>

--- a/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
+++ b/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
@@ -21,7 +21,7 @@
 #include <cav_srvs/SetEnableRobotic.h>
 #include <pacmod_msgs/SystemRptInt.h>
 #include <automotive_navigation_msgs/ModuleState.h>
-#include <j2735_msgs/TransmissionState.h>
+#include <j2735_v2x_msgs/TransmissionState.h>
 
 class SSCInterfaceWrapperWorker
 {

--- a/ssc_interface_wrapper/package.xml
+++ b/ssc_interface_wrapper/package.xml
@@ -12,7 +12,7 @@
   <depend>can_msgs</depend>
   <depend>cav_driver_utils</depend>
   <depend>cav_msgs</depend>
-  <depend>j2735_msgs</depend>
+  <depend>j2735_v2x_msgs</depend>
   <depend>cav_srvs</depend>
   <depend>autoware_msgs</depend>
   <depend>automotive_navigation_msgs</depend>

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
@@ -36,7 +36,7 @@ void SSCInterfaceWrapper::initialize() {
     // Initialize all publishers
     steering_wheel_angle_pub_ = nh_->advertise<std_msgs::Float64>("can/steering_wheel_angle", 1);
     brake_position_pub_ = nh_->advertise<std_msgs::Float64>("can/brake_position", 1);
-    transmission_pub_ = nh_->advertise<j2735_msgs::TransmissionState>("can/transmission_state", 1);
+    transmission_pub_ = nh_->advertise<j2735_v2x_msgs::TransmissionState>("can/transmission_state", 1);
     robot_status_pub_   = nh_->advertise<cav_msgs::RobotEnabled>("controller/robot_status", 1);
     vehicle_engage_pub_ = nh_->advertise<std_msgs::Bool>("vehicle/engage", 5);
     hazard_light_cmd_pub_ = nh_->advertise<pacmod_msgs::SystemCmdBool>("as_rx/hazard_lights", 5);
@@ -154,7 +154,7 @@ void SSCInterfaceWrapper::brake_cb(const pacmod_msgs::SystemRptFloatConstPtr& ms
 
 void SSCInterfaceWrapper::shift_cb(const pacmod_msgs::SystemRptIntConstPtr& msg)
 {
-    j2735_msgs::TransmissionState transmission_msg;
+    j2735_v2x_msgs::TransmissionState transmission_msg;
     transmission_msg.transmission_state = worker_.convert_shift_state_to_J2735(msg);
     transmission_pub_.publish(transmission_msg);
 }

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -53,15 +53,15 @@ int SSCInterfaceWrapperWorker::convert_shift_state_to_J2735(const pacmod_msgs::S
 	switch(shift_state -> output)
 	{
 	case pacmod_msgs::SystemRptInt::SHIFT_PARK:
-		return j2735_msgs::TransmissionState::PARK;
+		return j2735_v2x_msgs::TransmissionState::PARK;
 	case pacmod_msgs::SystemRptInt::SHIFT_REVERSE:
-		return j2735_msgs::TransmissionState::REVERSEGEARS;
+		return j2735_v2x_msgs::TransmissionState::REVERSEGEARS;
 	case pacmod_msgs::SystemRptInt::SHIFT_NEUTRAL:
-		return j2735_msgs::TransmissionState::NEUTRAL;
+		return j2735_v2x_msgs::TransmissionState::NEUTRAL;
 	case pacmod_msgs::SystemRptInt::SHIFT_FORWARD:
-		return j2735_msgs::TransmissionState::FORWARDGEARS;
+		return j2735_v2x_msgs::TransmissionState::FORWARDGEARS;
 	default:
-		return j2735_msgs::TransmissionState::UNAVAILABLE;
+		return j2735_v2x_msgs::TransmissionState::UNAVAILABLE;
 	}
 }
 


### PR DESCRIPTION
# PR Details
## Description

This PR renames the `j2735_msgs` and `j3224_msgs` packages after these packages were merged into `j2735_v2x_msgs` and `j3224_v2x_msgs` in [carma-msgs PR #243](https://github.com/usdot-fhwa-stol/carma-msgs/pull/243).

## Related GitHub Issue

NA

## Related Jira Key

[ARC-205](https://usdot-carma.atlassian.net/browse/ARC-205)

## Motivation and Context

Old package names are outdated and no longer exist.

## How Has This Been Tested?

Untested - Marked as draft

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ARC-205]: https://usdot-carma.atlassian.net/browse/ARC-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ