### PR TITLE
Update ssc_interface_wrapper.launch

### DIFF
--- a/ssc_interface_wrapper/launch/ssc_interface_wrapper.launch
+++ b/ssc_interface_wrapper/launch/ssc_interface_wrapper.launch
@@ -34,7 +34,7 @@
   <!-- Node exists in carma-utils repository-->
   <group if="$(arg enable_ros1_record)">
     <!-- Set up the rosbag record node that will exclude sensitive topics -->
-    <group ns="carma_record">
+    <group ns="/carma_record">
       <include file="$(find carma_record)/launch/carma_record.launch" />
     </group>
 

--- a/ssc_interface_wrapper/launch/ssc_interface_wrapper.launch
+++ b/ssc_interface_wrapper/launch/ssc_interface_wrapper.launch
@@ -24,7 +24,7 @@
   <arg name="vehicle_config_dir" default="/opt/carma/vehicle/config" doc="The directory containing vehicle config type parameters"/>
 
   <!-- Load Vehicle Topic Exclusion Rules -->
-  <rosparam command="load" file="$(arg vehicle_config_dir)/VehicleConfigParams.yaml"/>
+  <rosparam command="load" file="$(arg vehicle_config_dir)/VehicleConfigParams.yaml" ns="/"/>
 
   <!-- Logging -->
   <!-- ROS Bag -->


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The launch file is called with external namespace /hardware_interface. 
That makes the param loads into /hardware_interface/use_ros1_rosbag destination rather than /use_ros1_rosbag  which is what we need.

This is fixed to make the parameter loading specific to global namespace `/`

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
ARC-175-system-launch-test
<!-- e.g. CAR-123 -->

## Motivation and Context
ROS2 Humble Upgrade 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Black Pacifca
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
